### PR TITLE
ci: update auto-author-assign v1.4.0 to v1.6.1

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -11,4 +11,5 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.4.0
+      - uses: toshimaru/auto-author-assign@v1.6.1
+      


### PR DESCRIPTION
# :eyes: What is this PR?
auto-author-assign actions를1.4.0버전에서 1.6.1 버전으로 업데이트
node 12 버전이 deprecated 되었기 때문에 변경

# :pushpin: Related issue(s)

# :pencil: Changes

# :camera: Attachment
