### PR TITLE
Fix: Storybook static files 폴더 설정 수정

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -34,6 +34,7 @@ module.exports = {
 
     return config;
   },
+  staticDirs: ['../public'],
   framework: '@storybook/react',
   core: {
     builder: '@storybook/builder-webpack5',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "storybook": "start-storybook -p 6006 -s ./public",
+    "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
   "dependencies": {


### PR DESCRIPTION
# :eyes: What is this PR?

- depreacted된 Storybook static files 제공 폴더 설정 방식 fix

# :pushpin: Related issue(s)

# :pencil: Changes

- `start-storybook` CLI script의 `-s` 플래그 옵션을 사용하여 static 파일 제공 디렉토리를 설정하는 방식이 deprecated 되었다고 하여 수정.
- `.storybook/main.js` 에 `staticDirs` 옵션을 사용하여 public 폴더를 static files serving 폴더로 설정. 

# :camera: Attachment
