### PR TITLE
Fix: Github 로그인 인증 취소시 callback 처리

### DIFF
--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -1,6 +1,7 @@
 import { GetStaticProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { Spinner } from '@components/common';
@@ -25,6 +26,14 @@ function Callback() {
       router.push('/');
     },
   });
+
+  useEffect(() => {
+    if (router.isReady && router.query.error) {
+      const loginPathname = localStorage.getItem('login-pathname');
+      if (loginPathname) router.push(loginPathname);
+      else router.push('/');
+    }
+  }, [router]);
 
   return (
     <Container>

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -4,7 +4,7 @@ export const DEVICON_URL = 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/'
 
 export const DEVRANK_REPOSITORY_URL = 'https://github.com/boostcampwm-2022/web21-devrank';
 
-export const GITHUB_AUTH_REQUEST_URL = `https://github.com/login/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID}`;
+export const GITHUB_AUTH_REQUEST_URL = `https://github.com/login/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID}&read=user`;
 
 export const CUBE_RANK = {
   ALL: 'all',


### PR DESCRIPTION
# :eyes: What is this PR?

- Github 로그인 인증 취소 시 cancel callback에 대한 처리
- error가 query에 존재시 이전 url로 routing

# :pushpin: Related issue(s)

- close #49 

# :pencil: Changes

- callback 페이지에서 error 쿼리가 담긴 url일 시 이전 페이지로 routing 처리
- Github 인증 요청 url 수정

# :camera: Attachment
