### PR TITLE
Fix: ranking, about 페이지 로그인 유지 오류 수정

### DIFF
--- a/frontend/src/pages/about.tsx
+++ b/frontend/src/pages/about.tsx
@@ -4,11 +4,14 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Image from 'next/image';
 import React from 'react';
 import styled from 'styled-components';
+import { useRefresh } from '@hooks';
 import { CubeIcon } from '@components/common';
 import { CUBE_RANK, DEVELOPER_INFORMATION } from '@utils/constants';
 
 function About() {
+  useRefresh();
   const { t } = useTranslation(['tier', 'about']);
+
   return (
     <Container>
       <Logo>

--- a/frontend/src/pages/ranking.tsx
+++ b/frontend/src/pages/ranking.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { useState } from 'react';
 import styled from 'styled-components';
+import { useRefresh } from '@hooks';
 import { CubeRankType } from '@type/common';
 import Filterbar from '@components/Filterbar';
 import Ranking from '@components/Ranking';
@@ -11,6 +12,7 @@ import { CUBE_RANK } from '@utils/constants';
 import { mockRanking } from '@utils/mockData';
 
 function ranking() {
+  useRefresh();
   const { t } = useTranslation(['ranking', 'common']);
   const [active, setActive] = useState<CubeRankType>(CUBE_RANK.ALL);
 


### PR DESCRIPTION
# :eyes: What is this PR?

Ranking, About 페이지에서 로그인 유지가 되지 않던 현상 수정

# :pushpin: Related issue(s)

- close #91 

# :pencil: Changes

- ranking, about 페이지 컴포넌트에 로그인 유지를 위한 useRefresh Hook 사용

# :camera: Attachment
