### PR TITLE
Feature: 메인 페이지 랭킹(전체, 급상승, 일일조회수) 백엔드 데이터 적용

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -16,15 +16,6 @@ const nextConfig = {
 
     return config;
   },
-  async rewrites() {
-    // api path proxy 설정
-    return [
-      {
-        source: '/api/:path*',
-        destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
-      },
-    ];
-  },
   images: {
     remotePatterns: [
       // 외부 이미지 허용

--- a/frontend/src/apis/auth.ts
+++ b/frontend/src/apis/auth.ts
@@ -1,7 +1,8 @@
+import { LoginResponse } from '@type/response';
 import axiosInstance from '@utils/axiosInstance';
 
-export const requestGithubLogin = async (code: string) => {
-  const { data } = await axiosInstance.post('/api/auth/login', {
+export const requestGithubLogin = async (code: string): Promise<LoginResponse> => {
+  const { data } = await axiosInstance.post('/auth/login', {
     code,
   });
 
@@ -9,11 +10,11 @@ export const requestGithubLogin = async (code: string) => {
 };
 
 export const requestUserLogout = async () => {
-  await axiosInstance.delete('/api/auth/logout');
+  await axiosInstance.delete('/auth/logout');
 };
 
-export const requestTokenRefresh = async () => {
-  const { data } = await axiosInstance.post('/api/auth/refresh');
+export const requestTokenRefresh = async (): Promise<LoginResponse> => {
+  const { data } = await axiosInstance.post('/auth/refresh');
 
   return data;
 };

--- a/frontend/src/apis/ranking.ts
+++ b/frontend/src/apis/ranking.ts
@@ -1,0 +1,38 @@
+import { RankingResponse } from '@type/response';
+import axiosInstance from '@utils/axiosInstance';
+
+export const requestTopRankingByScore = async (count = 20): Promise<RankingResponse[]> => {
+  const { data } = await axiosInstance.get('/api/ranking', {
+    params: {
+      count,
+    },
+  });
+
+  return data;
+};
+
+export const requestTopRankingByRising = async (count = 3): Promise<RankingResponse[]> => {
+  const { data } = await axiosInstance.get('/api/ranking/rise', {
+    params: {
+      count,
+    },
+  });
+
+  return data;
+};
+
+export const requestTopRankingByViews = async (count = 3): Promise<RankingResponse[]> => {
+  const { data } = await axiosInstance.get('/api/ranking/views', {
+    params: {
+      count,
+    },
+  });
+
+  return data;
+};
+
+export const requestRankingByUsername = async (username: string) => {
+  const { data } = await axiosInstance.get(`/api/ranking/${username}`);
+
+  return data;
+};

--- a/frontend/src/apis/ranking.ts
+++ b/frontend/src/apis/ranking.ts
@@ -2,7 +2,7 @@ import { RankingResponse } from '@type/response';
 import axiosInstance from '@utils/axiosInstance';
 
 export const requestTopRankingByScore = async (count = 20): Promise<RankingResponse[]> => {
-  const { data } = await axiosInstance.get('/api/ranking', {
+  const { data } = await axiosInstance.get('/ranking', {
     params: {
       count,
     },
@@ -12,7 +12,7 @@ export const requestTopRankingByScore = async (count = 20): Promise<RankingRespo
 };
 
 export const requestTopRankingByRising = async (count = 3): Promise<RankingResponse[]> => {
-  const { data } = await axiosInstance.get('/api/ranking/rise', {
+  const { data } = await axiosInstance.get('/ranking/rise', {
     params: {
       count,
     },
@@ -22,7 +22,7 @@ export const requestTopRankingByRising = async (count = 3): Promise<RankingRespo
 };
 
 export const requestTopRankingByViews = async (count = 3): Promise<RankingResponse[]> => {
-  const { data } = await axiosInstance.get('/api/ranking/views', {
+  const { data } = await axiosInstance.get('/ranking/views', {
     params: {
       count,
     },
@@ -32,7 +32,7 @@ export const requestTopRankingByViews = async (count = 3): Promise<RankingRespon
 };
 
 export const requestRankingByUsername = async (username: string) => {
-  const { data } = await axiosInstance.get(`/api/ranking/${username}`);
+  const { data } = await axiosInstance.get(`/ranking/${username}`);
 
   return data;
 };

--- a/frontend/src/hooks/useRefresh.ts
+++ b/frontend/src/hooks/useRefresh.ts
@@ -2,9 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { requestTokenRefresh } from '@apis/auth';
 
 function useRefresh() {
-  useQuery(['user'], requestTokenRefresh, {
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
+  return useQuery(['user'], requestTokenRefresh, {
     retry: false,
     cacheTime: Infinity,
   });

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -9,7 +9,25 @@ import GlobalStyles from '@styles/globalStyles';
 import theme from '@styles/theme';
 import { lineSeedKR } from '@utils/fonts';
 
-const queryClient = new QueryClient();
+const queryErrorHandler = (error: unknown) => {
+  if (error instanceof Error) {
+    console.error(error.message);
+  }
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+      onError: queryErrorHandler,
+    },
+    mutations: {
+      onError: queryErrorHandler,
+    },
+  },
+});
 
 function App({ Component, pageProps }: AppProps) {
   return (

--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -12,10 +12,7 @@ function Callback() {
 
   useQuery(['user'], () => requestGithubLogin(router.query.code as string), {
     cacheTime: Infinity,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
     enabled: !!router.query.code,
-    select: (data) => data.user,
     onSuccess: () => {
       const loginPathname = localStorage.getItem('login-pathname');
       if (loginPathname) router.push(loginPathname);

--- a/frontend/src/type/response.ts
+++ b/frontend/src/type/response.ts
@@ -1,0 +1,15 @@
+export interface LoginResponse {
+  id: string;
+  username: string;
+  avatarUrl: string;
+  accessToken: string;
+}
+
+export interface RankingResponse {
+  id: string;
+  username: string;
+  avatarUrl: string;
+  dailyViews: number;
+  score: number;
+  scoreDifference: number;
+}

--- a/frontend/src/utils/axiosInstance.ts
+++ b/frontend/src/utils/axiosInstance.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 const instance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -21,10 +22,10 @@ instance.interceptors.response.use(
     const originConfig = err.config;
 
     // 요청했는데 token 만료면 token refresh 요청
-    if (originConfig.url !== '/api/auth/login' && err.response) {
+    if (originConfig.url !== '/auth/login' && err.response) {
       if (err.response.status === 401 && err.response.retry) {
         try {
-          const { data } = await instance.post('/api/auth/refresh');
+          const { data } = await instance.post('/auth/refresh');
           axios.defaults.headers.common['Authorization'] = `Bearer ${data.accessToken}`;
 
           return instance(originConfig);


### PR DESCRIPTION
# :eyes: What is this PR?

- 메인 페이지 랭킹(전체, 급상승, 일일조회수) mock 데이터에서 백엔드 API 데이터로 적용

# :pushpin: Related issue(s)

- #97 

# :pencil: Changes

- auth및 ranking API Response interface 선언
- next.js rewrite(proxy) 설정 제거 -> next에서 SSR을 사용할때(`getServerSideProps`에서) rewrite설정이 적용되지 않아 API 요청함수에서 동일한 url을 사용할 수 없는 이슈가 발생해 rewrite설정을 제거하고 API요청을 백엔드에 direct하게 하는 형식으로 변경 
- tanstack-query 공통 설정 query client 선언시 설정
- 메인페이지 전체, 급상승 유저, 일일조회수 랭킹 백엔드 API 데이터 적용해 렌더링, SSR방식으로 미리 데이터를 fetch해와 초기 페이지 로드시 바로 데이터가 표시되게 구현 

# :camera: Attachment

![image](https://user-images.githubusercontent.com/39851220/203758031-3e7315cd-ab34-4244-a597-4685563e1121.png)
