### PR TITLE
feat: 가입되지 않은 유저정보를 호출

### DIFF
--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -27,7 +27,7 @@ export class UserRepository {
 
   async createOrUpdate(user: UserDto): Promise<UserDto> {
     const filter = { id: user.id };
-    return this.userModel.findOneAndUpdate(filter, user, { upsert: true }).lean().exec();
+    return this.userModel.findOneAndUpdate(filter, user, { upsert: true, new: true }).lean().exec();
   }
 
   async findAllByUsername(limit = 15, username: string): Promise<UserDto[]> {

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -109,7 +109,7 @@ export class UserService {
             totalCount
           }
           repositories(
-            first: 10
+            first: 100
             isFork: false
             privacy: PUBLIC
             orderBy: {field: STARGAZERS, direction: DESC}
@@ -119,11 +119,11 @@ export class UserService {
               defaultBranchRef {
                 target {
                   ... on Commit {
-                    history(author: {id: $id}) {
+                    history(
+                      author: {id: $id}
+                      first: 100
+                    ) {
                       totalCount
-                      nodes {
-                        committedDate
-                      }
                     }
                   }
                 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -20,7 +20,17 @@ export class UserService {
   async findOneByUsername(username: string): Promise<UserDto> {
     const user = await this.userRepository.findOneByUsername(username);
     if (!user) {
-      throw new NotFoundException('user not found');
+      const octokit = new Octokit();
+      const res = await octokit.request('GET /users/{username}', {
+        username: username,
+      });
+      const userDto = new UserDto();
+      userDto.username = res.data.login;
+      userDto.avatarUrl = res.data.avatar_url;
+      userDto.commitsScore = 0;
+      userDto.followersScore = 0;
+      userDto.score = 0;
+      return this.userRepository.createOrUpdate(userDto);
     }
     return user;
   }
@@ -62,7 +72,17 @@ export class UserService {
       user = await this.userRepository.findOneByUsernameAndUpdateViews(username);
     }
     if (!user) {
-      throw new NotFoundException('User not found');
+      const octokit = new Octokit();
+      const res = await octokit.request('GET /users/{username}', {
+        username: username,
+      });
+      const userDto = new UserDto();
+      userDto.username = res.data.login;
+      userDto.avatarUrl = res.data.avatar_url;
+      userDto.commitsScore = 0;
+      userDto.followersScore = 0;
+      userDto.score = 0;
+      user = this.userRepository.createOrUpdate(userDto);
     }
     this.userRepository.setDuplicatedRequestIp(ip, username);
     user.updateDelayTime = updateDelayTime;
@@ -88,7 +108,7 @@ export class UserService {
             totalCount
           }
           repositories(
-            first: 100
+            first: 50
             isFork: false
             privacy: PUBLIC
             orderBy: {field: STARGAZERS, direction: DESC}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -84,8 +84,11 @@ export class UserService {
       userDto.followersScore = 0;
       userDto.score = 0;
       user = await this.userRepository.createOrUpdate(userDto);
+      console.log(user);
     }
+    console.log(user);
     this.userRepository.setDuplicatedRequestIp(ip, username);
+    console.log(updateDelayTime);
     user.updateDelayTime = updateDelayTime;
     return user;
   }
@@ -160,7 +163,9 @@ export class UserService {
       }
       const totalScore =
         ((repository.stargazers.totalCount + repository.forks.totalCount) *
-          repository.defaultBranchRef.target.history.totalCount) /
+          (repository.defaultBranchRef.target.history.totalCount > 100
+            ? 100
+            : repository.defaultBranchRef.target.history.totalCount)) /
         1000;
       console.log(repository.name, totalScore);
       return acc + totalScore;

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -77,12 +77,13 @@ export class UserService {
         username: username,
       });
       const userDto = new UserDto();
+      userDto.id = res.data.node_id;
       userDto.username = res.data.login;
       userDto.avatarUrl = res.data.avatar_url;
       userDto.commitsScore = 0;
       userDto.followersScore = 0;
       userDto.score = 0;
-      user = this.userRepository.createOrUpdate(userDto);
+      user = await this.userRepository.createOrUpdate(userDto);
     }
     this.userRepository.setDuplicatedRequestIp(ip, username);
     user.updateDelayTime = updateDelayTime;
@@ -108,7 +109,7 @@ export class UserService {
             totalCount
           }
           repositories(
-            first: 50
+            first: 10
             isFork: false
             privacy: PUBLIC
             orderBy: {field: STARGAZERS, direction: DESC}
@@ -158,7 +159,7 @@ export class UserService {
         return acc + 0;
       }
       const totalScore =
-        ((repository.stargazers.totalCount * 2 + repository.forks.totalCount) *
+        ((repository.stargazers.totalCount + repository.forks.totalCount) *
           repository.defaultBranchRef.target.history.totalCount) /
         1000;
       console.log(repository.name, totalScore);
@@ -166,6 +167,7 @@ export class UserService {
     }, 0);
     user.commitsScore = score;
     console.log(res2.user);
+    user.followers = res2.user.followers.totalCount;
     user.followersScore = res2.user.followers.totalCount;
     user.score = user.commitsScore + user.followersScore;
     user.tier = getTier(user.score);


### PR DESCRIPTION
# :eyes: What is this PR?
본인 소유레포가 아닌 fork 레포에 대한 기여 점수 산정
가입되지 않은 유저정보를 호출시 새로 user 를 생성
활동이 굉장히 많을경우 graphql 쿼리의 timeout이 발생하기 때문에 가져오는 repository 갯수를 100 > 50개로 수정

# :pushpin: Related issue(s)

# :pencil: Changes

# :camera: Attachment
