### PR TITLE
Feature: 랭킹 페이지 등급별 필터링 구현

### DIFF
--- a/frontend/src/apis/ranking.ts
+++ b/frontend/src/apis/ranking.ts
@@ -1,10 +1,27 @@
+import { CubeRankType } from '@type/common';
 import { RankingResponse } from '@type/response';
 import axiosInstance from '@utils/axiosInstance';
+import { CUBE_RANK } from '@utils/constants';
 
-export const requestTopRankingByScore = async (limit = 20): Promise<RankingResponse[]> => {
+interface RequestTopRankingByScoreParams {
+  page?: number;
+  limit?: number;
+  tier?: CubeRankType;
+  username?: string;
+}
+
+export const requestTopRankingByScore = async ({
+  page = 1,
+  limit = 10,
+  tier = CUBE_RANK.ALL,
+  username = '',
+}: RequestTopRankingByScoreParams): Promise<RankingResponse[]> => {
   const { data } = await axiosInstance.get('/rankings', {
     params: {
+      page,
       limit,
+      tier,
+      username,
     },
   });
 

--- a/frontend/src/components/common/Avatar/index.tsx
+++ b/frontend/src/components/common/Avatar/index.tsx
@@ -23,7 +23,7 @@ function Avatar({ src, size = 'md', name, onClick }: AvatarProps) {
   return (
     <Container>
       <ImageContainer size={size} onClick={onClick}>
-        <Image src={src} alt='프로필 이미지' fill />
+        <Image src={src} alt='프로필 이미지' sizes='50vw' fill />
       </ImageContainer>
       {name && <span>{name}</span>}
     </Container>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -18,7 +18,10 @@ function Home(props: any) {
   const { t } = useTranslation(['index', 'common']);
   const { data: rankingByScore } = useQuery<RankingResponse[]>(
     ['top-ranking-by-score'],
-    () => requestTopRankingByScore(12),
+    () =>
+      requestTopRankingByScore({
+        limit: 12,
+      }),
     {
       initialData: props.topRankingByScore,
     },
@@ -180,7 +183,9 @@ export default Home;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const [topRankingByScore, topRankingByRising, topRankingByViews] = await Promise.all([
-    requestTopRankingByScore(12),
+    requestTopRankingByScore({
+      limit: 12,
+    }),
     requestTopRankingByRising(),
     requestTopRankingByViews(),
   ]);

--- a/frontend/src/pages/ranking.tsx
+++ b/frontend/src/pages/ranking.tsx
@@ -1,20 +1,38 @@
-import { GetServerSideProps } from 'next';
+import { GetServerSideProps, NextPage } from 'next';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useRefresh } from '@hooks';
+import { useQuery } from '@tanstack/react-query';
 import { CubeRankType } from '@type/common';
+import { RankingResponse } from '@type/response';
 import Filterbar from '@components/Filterbar';
-import Ranking from '@components/Ranking';
+import RankingTable from '@components/Ranking';
 import { Avatar, CubeIcon, LanguageIcon, Searchbar } from '@components/common';
+import { requestTopRankingByScore } from '@apis/ranking';
 import { CUBE_RANK } from '@utils/constants';
-import { mockRanking } from '@utils/mockData';
 
-function ranking() {
+interface RankingPageProps {
+  ranking: RankingResponse[];
+}
+
+const Ranking: NextPage<RankingPageProps> = ({ ranking }) => {
   useRefresh();
   const { t } = useTranslation(['ranking', 'common']);
   const [active, setActive] = useState<CubeRankType>(CUBE_RANK.ALL);
+  const { data, refetch } = useQuery<RankingResponse[]>(
+    ['ranking'],
+    () => requestTopRankingByScore({ limit: 10, tier: active }),
+    {
+      initialData: ranking,
+      keepPreviousData: true,
+    },
+  );
+
+  useEffect(() => {
+    refetch();
+  }, [active]);
 
   return (
     <Container>
@@ -30,49 +48,54 @@ function ranking() {
           onSubmit={(e) => {}}
         />
       </SearchbarContainer>
-      <Ranking
+      <RankingTable
         width={'100%'}
         columnWidthList={['8%', '52%', '10%', '10%', '20%']}
         columnAlignList={['center', 'left', 'left', 'left', 'center']}
       >
-        <Ranking.Head>
-          <Ranking.Element>#</Ranking.Element>
-          <Ranking.Element>{t('common:table-user')}</Ranking.Element>
-          <Ranking.Element>{t('common:table-tier')}</Ranking.Element>
-          <Ranking.Element>{t('common:table-score')}</Ranking.Element>
-          <Ranking.Element>{t('common:table-tech-stack')}</Ranking.Element>
-        </Ranking.Head>
-        {mockRanking.map((data) => (
-          <Ranking.Row key={data.id}>
-            <Ranking.Element>{data.id}</Ranking.Element>
-            <Ranking.Element>
-              <Avatar src={data.avatarUrl} name={data.username} />
-            </Ranking.Element>
-            <Ranking.Element>
-              <CubeIcon tier={data.tier as CubeRankType} />
-            </Ranking.Element>
-            <Ranking.Element>{data.score}</Ranking.Element>
-            <Ranking.Element>
+        <RankingTable.Head>
+          <RankingTable.Element>#</RankingTable.Element>
+          <RankingTable.Element>{t('common:table-user')}</RankingTable.Element>
+          <RankingTable.Element>{t('common:table-tier')}</RankingTable.Element>
+          <RankingTable.Element>{t('common:table-score')}</RankingTable.Element>
+          <RankingTable.Element>{t('common:table-tech-stack')}</RankingTable.Element>
+        </RankingTable.Head>
+        {data?.map(({ id, username, avatarUrl, tier, score }, index) => (
+          <RankingTable.Row key={id}>
+            <RankingTable.Element>{index + 1}</RankingTable.Element>
+            <RankingTable.Element>
+              <Avatar src={avatarUrl} name={username} />
+            </RankingTable.Element>
+            <RankingTable.Element>
+              <CubeIcon tier={tier} />
+            </RankingTable.Element>
+            <RankingTable.Element>{score}</RankingTable.Element>
+            <RankingTable.Element>
+              {/* TODO: 기술스택 아이콘으로 변경
               <TechStackList>
                 {data.langs.map((lang) => (
                   <li key={lang}>
                     <LanguageIcon language={lang} width={35} height={35} />
                   </li>
                 ))}
-              </TechStackList>
-            </Ranking.Element>
-          </Ranking.Row>
+              </TechStackList> */}
+            </RankingTable.Element>
+          </RankingTable.Row>
         ))}
-      </Ranking>
+      </RankingTable>
     </Container>
   );
-}
+};
 
-export default ranking;
+export default Ranking;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+  const ranking = await requestTopRankingByScore({
+    limit: 10,
+  });
   return {
     props: {
+      ranking,
       ...(await serverSideTranslations(context.locale as string, ['common', 'header', 'footer', 'tier', 'ranking'])),
     },
   };


### PR DESCRIPTION
# :eyes: What is this PR?

랭킹 페이지에서 필터바를 통한 순위 목록 등급 필터링 기능을 구현

# :pushpin: Related issue(s)

- close #68

# :pencil: Changes

- GET /rankings API request parameter수정에 따른 api 요청함수 파라미터 수정
- 랭킹페이지 SSR 방식 랭킹데이터 fetch 후 렌더링
- useEffect를 통한 active 등급 변경에 따른 query refetch 구현

# :camera: Attachment

![rank-filter](https://user-images.githubusercontent.com/39851220/203953879-1c625e6e-d9b8-4f72-b4f5-0c5699abef19.gif)
