### PR TITLE
Fix: update delay를 응답이 반환될 때 기준으로 수정 / redis volume 연결

### DIFF
--- a/backend/infra/docker-compose.yml
+++ b/backend/infra/docker-compose.yml
@@ -37,5 +37,7 @@ services:
   redis:
     image: redis:6.2.5
     command: redis-server
+    volumes:
+      - /usr/local/redis/data:/data
     ports:
       - 6379:6379

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { CookieOptions } from 'express';
 import { Request } from 'express';
 import * as jwt from 'jsonwebtoken';
+import * as URL from 'url';
 import { AuthRepository } from './auth.repository';
 import { GithubProfile } from './types';
 
@@ -85,7 +86,8 @@ export class AuthService {
 
   getCookieOption = (): CookieOptions => {
     const maxAge = EXPIRATION.REFRESH_TOKEN * 1000;
-    const domain = this.configService.get('CLIENT_URL');
+
+    const domain = URL.parse(this.configService.get('CLIENT_URL')).host;
 
     if (this.configService.get('NODE_ENV') === 'production') {
       return { httpOnly: true, secure: true, sameSite: 'lax', maxAge, domain };

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -69,11 +69,13 @@ export class UserController {
     if ((await this.userService.findUpdateScoreTimeToLive(username)) > 0) {
       throw new BadRequestException('user score has been updated recently.');
     }
-    await this.userService.setUpdateScoreDelayTime(username, UPDATE_DELAY_TIME);
-    return await this.userService.updateUser(
+    const user = await this.userService.updateUser(
       username,
       githubToken || this.configService.get('GITHUB_PERSONAL_ACCESS_TOKEN'),
     );
+    await this.userService.setUpdateScoreDelayTime(username, UPDATE_DELAY_TIME);
+    user.updateDelayTime = UPDATE_DELAY_TIME + 3;
+    return user;
   }
 
   @Patch('')


### PR DESCRIPTION
# :eyes: What is this PR?
- user update delay time을 응답이 반환될 때 부터 count되도록 변경
- redis volume 연결
# :pushpin: Related issue(s)
- close #155 

# :pencil: Changes

# :camera: Attachment
