### PR TITLE
fix: scoreHistory가 1개인 경우 scoreDifference 0

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -72,7 +72,6 @@ export class AuthController {
     } catch {
       await this.userService.createOrUpdate(user);
       user = await this.userService.updateUser(user.username, githubToken);
-      user.scoreHistory.push({ score: user.score, date: new Date() });
       await this.userService.createOrUpdate(user);
     }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -40,8 +40,6 @@ export class UserService {
     }
 
     if (!user) user = await this.updateUser(username, githubToken);
-    if (!user.scoreHistory) user.scoreHistory = [];
-    user.scoreHistory.push({ date: new Date(), score: user.score });
     await this.userRepository.createOrUpdate(user);
     const { totalRank, tierRank } = await this.getUserRelativeRanking(user);
     this.userRepository.setDuplicatedRequestIp(ip, username);
@@ -114,8 +112,12 @@ export class UserService {
           date: new Date(),
           score: user.score,
         });
-        updatedUser.scoreDifference =
-          updatedUser.score - updatedUser.scoreHistory[updatedUser.scoreHistory.length - 2].score;
+        if (updatedUser.scoreHistory.length > 1) {
+          updatedUser.scoreDifference =
+            updatedUser.score - updatedUser.scoreHistory[updatedUser.scoreHistory.length - 2].score;
+        } else {
+          updatedUser.scoreDifference = 0;
+        }
         updatedUser.dailyViews = 0;
         this.userRepository.createOrUpdate(updatedUser);
       } catch {


### PR DESCRIPTION
# :eyes: What is this PR?
처음 가입된 유저의 경우 처음 생성되는 모든 점수가 scoreDifference로 집계되기 때문에 이를 방지하기 위해 가입 2일차부터 scoreDifference 적용

# :pushpin: Related issue(s)

# :pencil: Changes

# :camera: Attachment
