### PR TITLE
Feature: 프로필 페이지 score history 추가 

### DIFF
--- a/frontend/src/components/Chart/LineChart.tsx
+++ b/frontend/src/components/Chart/LineChart.tsx
@@ -1,45 +1,51 @@
 import styled from 'styled-components';
 import theme from './theme.json';
-import { ResponsiveLine, Serie } from '@nivo/line';
+import { CartesianMarkerProps } from '@nivo/core';
+import { DatumValue, ResponsiveLine, Serie } from '@nivo/line';
 
 interface LineChartProps {
   data: Serie[];
+  min?: number;
+  max?: number;
+  markers?: CartesianMarkerProps<DatumValue>[];
 }
 
-function LineChart({ data }: LineChartProps) {
+function LineChart({ data, min, max, markers }: LineChartProps) {
   return (
-    <ResponsiveLine
-      theme={theme}
-      data={data}
-      colors={{ datum: 'color' }}
-      margin={{ top: 60, right: 60, bottom: 60, left: 60 }}
-      curve='monotoneX'
-      enableArea={true}
-      xScale={{
-        type: 'time',
-        format: '%Y-%m-%d',
-        useUTC: false,
-        precision: 'day',
-      }}
-      xFormat='time:%Y-%m-%d'
-      yScale={{
-        type: 'linear',
-        stacked: true,
-        min: 0,
-        max: 'auto',
-      }}
-      axisBottom={{
-        format: '%b',
-        tickValues: 'every month',
-        legend: 'Date',
-        legendOffset: 48,
-        legendPosition: 'middle',
-      }}
-      tooltip={(props) => <Tooltip>{`${props.point.data.y} contribution on ${props.point.data.xFormatted}`}</Tooltip>}
-      enablePoints={false}
-      useMesh={true}
-      enableSlices={false}
-    />
+    <>
+      <ResponsiveLine
+        theme={theme}
+        data={data}
+        colors={{ datum: 'color' }}
+        margin={{ top: 60, right: 60, bottom: 60, left: 60 }}
+        curve='monotoneX'
+        enableArea={true}
+        xScale={{
+          type: 'time',
+          format: '%Y-%m-%d',
+          useUTC: false,
+          precision: 'day',
+        }}
+        xFormat='time:%Y-%m-%d'
+        yScale={{
+          type: 'linear',
+          min: min || 0,
+          max: max || 'auto',
+        }}
+        axisBottom={{
+          format: '%b',
+          tickValues: 'every month',
+          legend: 'Date',
+          legendOffset: 48,
+          legendPosition: 'middle',
+        }}
+        tooltip={(props) => <Tooltip>{`${props.point.data.y} contribution on ${props.point.data.xFormatted}`}</Tooltip>}
+        enablePoints={false}
+        useMesh={true}
+        enableSlices={false}
+        markers={markers}
+      />
+    </>
   );
 }
 

--- a/frontend/src/components/Chart/LineChart/index.tsx
+++ b/frontend/src/components/Chart/LineChart/index.tsx
@@ -1,16 +1,16 @@
-import styled from 'styled-components';
-import theme from './theme.json';
+import theme from '../theme.json';
 import { CartesianMarkerProps } from '@nivo/core';
-import { DatumValue, ResponsiveLine, Serie } from '@nivo/line';
+import { DatumValue, PointTooltip, ResponsiveLine, Serie } from '@nivo/line';
 
 interface LineChartProps {
   data: Serie[];
   min?: number;
   max?: number;
   markers?: CartesianMarkerProps<DatumValue>[];
+  tooltip?: PointTooltip;
 }
 
-function LineChart({ data, min, max, markers }: LineChartProps) {
+function LineChart({ data, min, max, markers, tooltip }: LineChartProps) {
   return (
     <>
       <ResponsiveLine
@@ -39,7 +39,7 @@ function LineChart({ data, min, max, markers }: LineChartProps) {
           legendOffset: 48,
           legendPosition: 'middle',
         }}
-        tooltip={(props) => <Tooltip>{`${props.point.data.y} contribution on ${props.point.data.xFormatted}`}</Tooltip>}
+        tooltip={tooltip}
         enablePoints={false}
         useMesh={true}
         enableSlices={false}
@@ -50,9 +50,3 @@ function LineChart({ data, min, max, markers }: LineChartProps) {
 }
 
 export default LineChart;
-
-const Tooltip = styled.div`
-  background-color: ${({ theme }) => theme.colors.gray7};
-  padding: 10px;
-  border-radius: 8px;
-`;

--- a/frontend/src/components/Chart/PieChart/index.tsx
+++ b/frontend/src/components/Chart/PieChart/index.tsx
@@ -1,4 +1,4 @@
-import theme from './theme.json';
+import theme from '../theme.json';
 import { ResponsivePie } from '@nivo/pie';
 
 interface PieChartProps {

--- a/frontend/src/components/Chart/Tooltip/index.tsx
+++ b/frontend/src/components/Chart/Tooltip/index.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+interface TooltipProps {
+  children: React.ReactNode;
+}
+
+function Tooltip({ children }: TooltipProps) {
+  return <StyledTooltip>{children}</StyledTooltip>;
+}
+
+export default Tooltip;
+
+const StyledTooltip = styled.div`
+  background-color: ${({ theme }) => theme.colors.gray7};
+  padding: 10px;
+  border-radius: 8px;
+`;

--- a/frontend/src/components/Chart/index.ts
+++ b/frontend/src/components/Chart/index.ts
@@ -1,0 +1,5 @@
+import LineChart from './LineChart';
+import PieChart from './PieChart';
+import Tooltip from './Tooltip';
+
+export { LineChart, PieChart, Tooltip };

--- a/frontend/src/components/Profile/ContributionStatistic/index.tsx
+++ b/frontend/src/components/Profile/ContributionStatistic/index.tsx
@@ -1,7 +1,10 @@
 import dynamic from 'next/dynamic';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
+import { RANK } from '@type/common';
 import { ProfileUserResponse } from '@type/response';
+import { TIER_OFFSET } from '@utils/constants';
 import {
+  getLineChartMinMaxValue,
   transContributionHistoryToLineChartData,
   transScoreHistoryToLineChartData,
   transToPieChartData,
@@ -15,19 +18,37 @@ interface ContributionStatisticProps {
 }
 
 function ContributionStatistic({ data }: ContributionStatisticProps) {
+  const theme = useTheme();
+  const pieChartData = transToPieChartData(data.history);
+  const contributionHistoryData = transContributionHistoryToLineChartData(data.history.contributionHistory, data.tier);
+  const scoreHistoryData = transScoreHistoryToLineChartData(data.scoreHistory, data.tier);
+  const { min, max } = getLineChartMinMaxValue(scoreHistoryData);
+
   return (
     <ChartContainer>
       <Chart>
         <ChartTitle>Contribution Statistics</ChartTitle>
-        <PieChart data={transToPieChartData(data.history)} />
+        <PieChart data={pieChartData} />
       </Chart>
       <Chart>
         <ChartTitle>Contribution History</ChartTitle>
-        <LineChart data={transContributionHistoryToLineChartData(data.history.contributionHistory, data.tier)} />
+        <LineChart data={contributionHistoryData} />
       </Chart>
       <Chart>
         <ChartTitle>Score History</ChartTitle>
-        <LineChart data={transScoreHistoryToLineChartData(data.scoreHistory, data.tier)} />
+        <LineChart
+          data={scoreHistoryData}
+          min={min}
+          max={max}
+          markers={Object.entries(TIER_OFFSET).map(([tier, score]) => ({
+            axis: 'y',
+            value: score,
+            lineStyle: { stroke: theme.colors[`${tier as RANK}2`], strokeWidth: 1, strokeDasharray: '4 4' },
+            legend: tier,
+            legendPosition: 'right',
+            textStyle: { fill: theme.colors[`${tier as RANK}2`], fontSize: 10, fontWeight: 'bold' },
+          }))}
+        />
       </Chart>
     </ChartContainer>
   );

--- a/frontend/src/components/Profile/ContributionStatistic/index.tsx
+++ b/frontend/src/components/Profile/ContributionStatistic/index.tsx
@@ -1,7 +1,11 @@
 import dynamic from 'next/dynamic';
 import styled from 'styled-components';
 import { ProfileUserResponse } from '@type/response';
-import { transToLineChartData, transToPieChartData } from '@utils/utils';
+import {
+  transContributionHistoryToLineChartData,
+  transScoreHistoryToLineChartData,
+  transToPieChartData,
+} from '@utils/utils';
 
 const PieChart = dynamic(() => import('@components/Chart/PieChart'), { ssr: false });
 const LineChart = dynamic(() => import('@components/Chart/LineChart'), { ssr: false });
@@ -19,7 +23,11 @@ function ContributionStatistic({ data }: ContributionStatisticProps) {
       </Chart>
       <Chart>
         <ChartTitle>Contribution History</ChartTitle>
-        <LineChart data={transToLineChartData(data.history.contributionHistory, data.tier)} />
+        <LineChart data={transContributionHistoryToLineChartData(data.history.contributionHistory, data.tier)} />
+      </Chart>
+      <Chart>
+        <ChartTitle>Score History</ChartTitle>
+        <LineChart data={transScoreHistoryToLineChartData(data.scoreHistory, data.tier)} />
       </Chart>
     </ChartContainer>
   );

--- a/frontend/src/components/Profile/ContributionStatistic/index.tsx
+++ b/frontend/src/components/Profile/ContributionStatistic/index.tsx
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic';
 import styled, { useTheme } from 'styled-components';
 import { RANK } from '@type/common';
 import { ProfileUserResponse } from '@type/response';
+import { Tooltip } from '@components/Chart';
 import { TIER_OFFSET } from '@utils/constants';
 import {
   getLineChartMinMaxValue,
@@ -32,7 +33,12 @@ function ContributionStatistic({ data }: ContributionStatisticProps) {
       </Chart>
       <Chart>
         <ChartTitle>Contribution History</ChartTitle>
-        <LineChart data={contributionHistoryData} />
+        <LineChart
+          data={contributionHistoryData}
+          tooltip={(props) => (
+            <Tooltip>{`${props.point.data.y} contribution on ${props.point.data.xFormatted}`}</Tooltip>
+          )}
+        />
       </Chart>
       <Chart>
         <ChartTitle>Score History</ChartTitle>
@@ -46,8 +52,9 @@ function ContributionStatistic({ data }: ContributionStatisticProps) {
             lineStyle: { stroke: theme.colors[`${tier as RANK}2`], strokeWidth: 1, strokeDasharray: '4 4' },
             legend: tier,
             legendPosition: 'right',
-            textStyle: { fill: theme.colors[`${tier as RANK}2`], fontSize: 10, fontWeight: 'bold' },
+            textStyle: { fill: theme.colors[`${tier as RANK}2`], fontSize: 12, fontWeight: 'bold' },
           }))}
+          tooltip={(props) => <Tooltip>{`${props.point.data.y} scores on ${props.point.data.xFormatted}`}</Tooltip>}
         />
       </Chart>
     </ChartContainer>

--- a/frontend/src/components/Profile/Statistic/index.tsx
+++ b/frontend/src/components/Profile/Statistic/index.tsx
@@ -18,7 +18,7 @@ interface ContributionStatisticProps {
   data: ProfileUserResponse;
 }
 
-function ContributionStatistic({ data }: ContributionStatisticProps) {
+function Statistic({ data }: ContributionStatisticProps) {
   const theme = useTheme();
   const pieChartData = transToPieChartData(data.history);
   const contributionHistoryData = transContributionHistoryToLineChartData(data.history.contributionHistory, data.tier);
@@ -61,7 +61,7 @@ function ContributionStatistic({ data }: ContributionStatisticProps) {
   );
 }
 
-export default ContributionStatistic;
+export default Statistic;
 
 const ChartContainer = styled.ul`
   ${({ theme }) => theme.common.flexCenterColumn};

--- a/frontend/src/components/Profile/index.ts
+++ b/frontend/src/components/Profile/index.ts
@@ -1,8 +1,8 @@
 import CommitHistory from './CommitHistory';
-import ContributionStatistic from './ContributionStatistic/index';
 import EXPbar from './EXPbar';
 import PinnedRepository from './PinnedRepository';
 import ProfileCard from './ProfileCard';
 import ProfileLabel from './ProfileLabel';
+import Statistic from './Statistic';
 
-export { CommitHistory, ContributionStatistic, ProfileCard, ProfileLabel, PinnedRepository, EXPbar };
+export { CommitHistory, Statistic, ProfileCard, ProfileLabel, PinnedRepository, EXPbar };

--- a/frontend/src/pages/profile/[username].tsx
+++ b/frontend/src/pages/profile/[username].tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { QueryClient, dehydrate, useMutation, useQuery } from '@tanstack/react-query';
 import { ProfileUserResponse } from '@type/response';
-import { CommitHistory, ContributionStatistic, EXPbar, PinnedRepository, ProfileCard } from '@components/Profile';
+import { CommitHistory, EXPbar, PinnedRepository, ProfileCard, Statistic } from '@components/Profile';
 import { Paper } from '@components/common';
 import HeadMeta from '@components/common/HeadMeta';
 import { requestTokenRefresh } from '@apis/auth';
@@ -74,7 +74,7 @@ function Profile({ username }: ProfileProps) {
           </Paper>
           <Title>Stats</Title>
           <Paper>
-            <ContributionStatistic data={data} />
+            <Statistic data={data} />
           </Paper>
           <Title>Pinned Repositories</Title>
           <Paper>

--- a/frontend/src/pages/profile/[username].tsx
+++ b/frontend/src/pages/profile/[username].tsx
@@ -30,7 +30,7 @@ function Profile({ username }: ProfileProps) {
     onSettled: () => refetch(),
   });
   const { t } = useTranslation(['profile', 'meta']);
-  
+
   const ogImage = `https://dreamdev.me/api/og-image/?username=${username}&tier=${data?.tier}&image=${data?.avatarUrl}`;
 
   return (

--- a/frontend/src/type/common.ts
+++ b/frontend/src/type/common.ts
@@ -40,6 +40,11 @@ export interface HistoryType {
   contributionHistory: { [key: string]: DailyInfo };
 }
 
+export interface ScoreHistory {
+  date: string;
+  score: number;
+}
+
 export interface OrganizationType {
   name: string;
   url: string;

--- a/frontend/src/type/response.ts
+++ b/frontend/src/type/response.ts
@@ -1,4 +1,4 @@
-import { CubeRankType, HistoryType, OrganizationType, PinnedRepositoryType, RANK } from '@type/common';
+import { CubeRankType, HistoryType, OrganizationType, PinnedRepositoryType, RANK, ScoreHistory } from '@type/common';
 
 export interface UserByPrefixResponse {
   id: number;
@@ -68,6 +68,7 @@ export interface ProfileUserResponse {
   email: string;
   dailyViews: number;
   scoreDifference: number;
+  scoreHistory: ScoreHistory[];
   updateDelayTime: number;
   primaryLanguages: [string];
   history: HistoryType;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -117,3 +117,12 @@ export const MEDAL_IMG: {
   1: '/icons/ranking-2nd.svg',
   2: '/icons/ranking-3rd.svg',
 };
+
+export const TIER_OFFSET = {
+  green: 100,
+  mint: 200,
+  blue: 500,
+  purple: 1000,
+  orange: 2000,
+  red: 5000,
+} as const;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -101,6 +101,15 @@ export const transScoreHistoryToLineChartData = (data: ScoreHistory[], tier: RAN
   ];
 };
 
+export const getLineChartMinMaxValue = (data: Serie[]) => {
+  const values = data[0].data.map((i) => i.y) as number[];
+  let min = Math.min(...values);
+  min = min <= 100 ? 0 : min - 100;
+  const max = Math.max(...values) + 100;
+
+  return { min, max };
+};
+
 interface QueryValidatorType {
   tier?: string | string[];
   username?: string | string[];

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from 'next-i18next';
 import { useTheme } from 'styled-components';
 import { Serie } from '@nivo/line';
-import { CubeRankType, DailyInfo, HistoryType, RANK } from '@type/common';
+import { CubeRankType, DailyInfo, HistoryType, RANK, ScoreHistory } from '@type/common';
 import { ProfileUserResponse } from '@type/response';
 import { CUBE_RANK, DEVICON_URL, EXCEPTIONAL_LANGUAGE } from '@utils/constants';
 
@@ -77,18 +77,28 @@ export const transToPieChartData = (data: HistoryType) => {
   ];
 };
 
-export const transToLineChartData = (data: { [key: string]: DailyInfo }, tier: RANK): Serie[] => {
+export const transContributionHistoryToLineChartData = (data: { [key: string]: DailyInfo }, tier: RANK): Serie[] => {
   const theme = useTheme();
 
-  const ret = [
+  return [
     {
       id: 'contribution',
       color: theme.colors[`${tier}2`],
       data: Object.entries(data).map(([key, value]) => ({ x: key, y: value.count })),
     },
   ];
+};
 
-  return ret;
+export const transScoreHistoryToLineChartData = (data: ScoreHistory[], tier: RANK): Serie[] => {
+  const theme = useTheme();
+
+  return [
+    {
+      id: 'contribution',
+      color: theme.colors[`${tier}2`],
+      data: data.map((value) => ({ x: value.date.slice(0, 10), y: value.score })),
+    },
+  ];
 };
 
 interface QueryValidatorType {


### PR DESCRIPTION
# :eyes: What is this PR?

프로필 페이지 통계영역 점수 히스토리 라인차트 표시

# :pushpin: Related issue(s)

- close #288

# :pencil: Changes

- 점수 히스토리 라인차트 추가
- 점수 히스토리 라인차트 등급 커트라인 표시
- 차트 컴포넌트 디렉토리 구조 리팩토링

# :camera: Attachment

- contribution 히스토리도 유의미해보여서 남겨둠
- 점수 히스토리는 데이터가 아직 하나밖에 없기 때문에 라인 차트가 그려지지 않는 상태. 

![image](https://user-images.githubusercontent.com/39851220/207050335-afecfce6-b3d2-463b-b845-31db2031d94c.png)
