### PR TITLE
Fix: score history 라인차트 수정

### DIFF
--- a/frontend/src/components/Chart/LineChart/index.tsx
+++ b/frontend/src/components/Chart/LineChart/index.tsx
@@ -20,6 +20,7 @@ function LineChart({ data, min, max, markers, tooltip }: LineChartProps) {
         margin={{ top: 60, right: 60, bottom: 60, left: 60 }}
         curve='monotoneX'
         enableArea={true}
+        areaBaselineValue={min || 0}
         xScale={{
           type: 'time',
           format: '%Y-%m-%d',

--- a/frontend/src/components/Chart/theme.json
+++ b/frontend/src/components/Chart/theme.json
@@ -29,7 +29,7 @@
     "legend": {
       "text": {
         "fontSize": 14,
-        "fontWeight": 700,
+        "fontWeight": 400,
         "fill": "#FBFBFB"
       }
     },

--- a/frontend/src/components/Chart/theme.json
+++ b/frontend/src/components/Chart/theme.json
@@ -39,7 +39,8 @@
         "strokeWidth": 1
       },
       "text": {
-        "fontSize": 14,
+        "fontSize": 12,
+        "fontWeight": 100,
         "fill": "#FBFBFB"
       }
     }

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -26,6 +26,14 @@ export const getDate = (dateString: string) => {
   return { year, month, date, day };
 };
 
+export const getKSTDateString = (date: Date) => {
+  const utc = date.getTime() + date.getTimezoneOffset() * 60 * 1000;
+  const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+  const kst_date = new Date(utc + KR_TIME_DIFF);
+
+  return `${kst_date.getFullYear()}-${kst_date.getMonth() + 1}-${kst_date.getDate()}`;
+};
+
 export const getProfileDescription = (locale: string, data: ProfileUserResponse) => {
   const { t } = useTranslation();
   const { tier, score, totalRank, tierRank, primaryLanguages } = data;
@@ -96,7 +104,7 @@ export const transScoreHistoryToLineChartData = (data: ScoreHistory[], tier: RAN
     {
       id: 'contribution',
       color: theme.colors[`${tier}2`],
-      data: data.map((value) => ({ x: value.date.slice(0, 10), y: value.score })),
+      data: data.map((value) => ({ x: getKSTDateString(new Date(value.date)), y: value.score })),
     },
   ];
 };


### PR DESCRIPTION
# :eyes: What is this PR?

- score history 라인차트 수정

# :pushpin: Related issue(s)

# :pencil: Changes

- 라인차트 선 아래 영역의 base line 설정
- 스코어 히스토리 데이터 시간을 한국시간(KST)로 고정
- 라인차트 axis  스타일 수정

# :camera: Attachment

![image](https://user-images.githubusercontent.com/39851220/207217945-cc6838bb-7257-41fc-b229-652e4c8da9fb.png)
