### PR TITLE
Fix: 한국 시간 기준으로 12시에 일일 조회수 초기화 되도록 수정

### DIFF
--- a/backend/libs/consts/index.ts
+++ b/backend/libs/consts/index.ts
@@ -14,4 +14,4 @@ export const RANK_CACHE_DELAY = 12 * HOUR;
 
 export const GITHUB_API_DELAY = 1500; // ms
 
-export const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+export const KR_TIME_DIFF = 9 * HOUR * 1000; // ms

--- a/backend/libs/consts/index.ts
+++ b/backend/libs/consts/index.ts
@@ -13,3 +13,5 @@ export const PAGE_UNIT_COUNT = 10;
 export const RANK_CACHE_DELAY = 12 * HOUR;
 
 export const GITHUB_API_DELAY = 1500; // ms
+
+export const KR_TIME_DIFF = 9 * 60 * 60 * 1000;

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -1,6 +1,6 @@
 import { RankingPaginationDto } from '@apps/ranking/dto/ranking-pagination.dto';
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
-import { RANK_CACHE_DELAY } from '@libs/consts';
+import { KR_TIME_DIFF, RANK_CACHE_DELAY } from '@libs/consts';
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import Redis from 'ioredis';
@@ -74,8 +74,7 @@ export class UserRepository {
 
   async setDuplicatedRequestIp(ip: string, lowerUsername: string): Promise<void> {
     this.redis.sadd(ip, lowerUsername);
-    const now = new Date();
-    now.setHours(now.getHours() + 9);
+    const now = +new Date() + KR_TIME_DIFF;
 
     const midNight = new Date(new Date().setHours(23, 59, 59));
     midNight.setHours(midNight.getHours() + 9);

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -74,7 +74,13 @@ export class UserRepository {
 
   async setDuplicatedRequestIp(ip: string, lowerUsername: string): Promise<void> {
     this.redis.sadd(ip, lowerUsername);
-    const timeToMidnight = Math.floor((new Date().setHours(23, 59, 59) - Date.now()) / 1000);
+    const now = new Date();
+    now.setHours(now.getHours() + 9);
+
+    const midNight = new Date(new Date().setHours(23, 59, 59));
+    midNight.setHours(midNight.getHours() + 9);
+
+    const timeToMidnight = Math.floor((+midNight - +now) / 1000);
     this.redis.expire(ip, timeToMidnight);
   }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { GITHUB_API_DELAY } from '@libs/consts';
+import { GITHUB_API_DELAY, KR_TIME_DIFF } from '@libs/consts';
 import { getNeedExp, getStartExp, getTier, logger } from '@libs/utils';
 import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { Octokit } from '@octokit/core';
@@ -78,7 +78,7 @@ export class UserService {
     if (!updatedUser?.scoreHistory?.length) {
       updatedUser.scoreHistory = [{ date: new Date(), score: updatedUser.score }];
     }
-    const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+
     const utc = updatedUser.scoreHistory[updatedUser.scoreHistory.length - 1].date.getTime();
     if (new Date(utc + KR_TIME_DIFF).getDate() === new Date(new Date().getTime() + KR_TIME_DIFF).getDate()) {
       updatedUser.scoreHistory.pop();


### PR DESCRIPTION
# :eyes: What is this PR?
- redis ttl이 UTC 기준으로 설정되서, 한국시간 자정이 지나도 일일 조회수 업데이트가 안되는 문제 해결
# :pushpin: Related issue(s)

# :pencil: Changes

# :camera: Attachment
