### PR TITLE
Feature: realtime ranking

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -7,6 +7,6 @@ export class AppController {
 
   @Get()
   getHello(): string {
-    return this.appService.getHello();
+    return this.appService.healthCheck();
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,6 +38,7 @@ import { AppService } from './app.service';
     UserModule,
     RankingModule,
     BatchModule,
+    UserModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,7 +38,6 @@ import { AppService } from './app.service';
     UserModule,
     RankingModule,
     BatchModule,
-    UserModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,8 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { logger } from '@libs/utils';
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { UserRepository } from './user/user.repository';
 
 @Injectable()
-export class AppService {
-  getHello(): string {
-    return 'Hello World!';
+export class AppService implements OnApplicationBootstrap {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async onApplicationBootstrap() {
+    const allUsers = await this.userRepository.findAll({}, false, ['lowerUsername', 'score', 'tier', 'history']);
+    await Promise.all(
+      allUsers
+        .filter((user) => user.history)
+        .map(({ lowerUsername, score, tier }) => this.userRepository.updateCachedUserRank(tier, score, lowerUsername)),
+    );
+    logger.log('all user score loaded in Redis.');
+  }
+
+  healthCheck(): string {
+    return 'devrank server is listening!';
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -74,16 +74,6 @@ export class AuthService {
     await this.authRepository.create(id, refreshToken);
   }
 
-  // async replaceRefreshToken(id: string, refreshToken: string, githubToken: string): Promise<string> {
-  //   const storedRefreshToken = await this.authRepository.findRefreshTokenById(id);
-  //   if (refreshToken !== storedRefreshToken) {
-  //     throw new UnauthorizedException('invalid token.');
-  //   }
-  //   const newRefreshToken = this.issueRefreshToken(id, githubToken);
-  //   await this.authRepository.create(id, newRefreshToken);
-  //   return newRefreshToken;
-  // }
-
   async deleteRefreshToken(id: string): Promise<void> {
     await this.authRepository.delete(id);
   }

--- a/backend/src/ranking/dto/ranking-user.dto.ts
+++ b/backend/src/ranking/dto/ranking-user.dto.ts
@@ -24,6 +24,9 @@ export class RankingUserDto {
   tier: string;
 
   @ApiProperty()
+  totalRank?: number;
+
+  @ApiProperty()
   primaryLanguages: string[];
 
   of(user: UserDto): RankingUserDto {
@@ -35,6 +38,7 @@ export class RankingUserDto {
     this.dailyViews = user.dailyViews;
     this.scoreDifference = user.scoreDifference;
     this.primaryLanguages = user.primaryLanguages;
+    this.totalRank = user.totalRank;
     return this;
   }
 }

--- a/backend/src/ranking/ranking.service.ts
+++ b/backend/src/ranking/ranking.service.ts
@@ -19,6 +19,11 @@ export class RankingService {
     if (!paginationResult?.metadata || paginationResult?.users.length === 0) {
       throw new NotFoundException('user not found.');
     }
+    for (const user of paginationResult.users) {
+      const [totalRank] = await this.userRepository.findCachedUserRank(user.tier, user.lowerUsername);
+      user.totalRank = totalRank;
+    }
+
     const lastPage = Math.ceil(paginationResult.metadata.total / limit);
     const lastPageGroupNumber = Math.ceil(lastPage / PAGE_UNIT_COUNT);
     const pageGroupNumber = Math.ceil(page / PAGE_UNIT_COUNT);

--- a/backend/src/user/dto/rank.dto.ts
+++ b/backend/src/user/dto/rank.dto.ts
@@ -1,4 +1,0 @@
-export class Rank {
-  totalRank: number;
-  tierRank: number;
-}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -78,6 +78,9 @@ export class UserDto {
   @ApiProperty({ type: History })
   history?: History;
 
+  @ApiProperty()
+  totalRank?: number;
+
   @ApiProperty({ isArray: true, type: PinnedRepositoryDto })
   pinnedRepositories?: PinnedRepositoryDto[];
 

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -6,7 +6,6 @@ import {
   Controller,
   DefaultValuePipe,
   Get,
-  NotFoundException,
   Param,
   ParseIntPipe,
   Patch,

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -9,6 +9,6 @@ import { UserService } from './user.service';
   imports: [MongooseModule.forFeature([{ name: User.name, schema: UserScheme }])],
   controllers: [UserController],
   providers: [UserService, UserRepository],
-  exports: [UserService],
+  exports: [UserService, UserRepository],
 })
 export class UserModule {}

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -119,9 +119,8 @@ export class UserRepository {
     return this.redis.hgetall(scoreKey) as unknown as Rank;
   }
 
-  async setCachedUserRank(scoreKey: string, scores: Rank): Promise<void> {
-    this.redis.hset(scoreKey, scores);
-    this.redis.expire(scoreKey, RANK_CACHE_DELAY);
+  async updateCachedUserRank(tier: string, score: number, lowerUsername: string): Promise<void> {
+    Promise.all([this.redis.zadd('all&', score, lowerUsername), this.redis.zadd(`${tier}&`, score, lowerUsername)]);
   }
 
   async deleteCachedUserRank(scoreKey: string): Promise<void> {

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -123,7 +123,7 @@ export class UserRepository {
     Promise.all([this.redis.zadd('all&', score, lowerUsername), this.redis.zadd(`${tier}&`, score, lowerUsername)]);
   }
 
-  async deleteCachedUserRank(scoreKey: string): Promise<void> {
-    this.redis.del(scoreKey);
+  async deleteCachedUserRank(tier: string, lowerUsername: string): Promise<void> {
+    this.redis.zrem(`${tier}&`, lowerUsername);
   }
 }

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -99,7 +99,7 @@ export class UserRepository {
     const result = (
       await this.userModel.aggregate([
         { $match: { ...tierOption, ...usernameOption } },
-        { $sort: { score: -1 } },
+        { $sort: { score: -1, lowerUsername: -1 } },
         {
           $facet: {
             metadata: [

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -336,30 +336,4 @@ export class UserService {
       }),
     };
   }
-
-  async getUserRelativeRanking(user: UserDto): Promise<Rank | false> {
-    const cachedRanks = await this.userRepository.findCachedUserRank(user.id + '&');
-    if (Object.keys(cachedRanks).length) {
-      return cachedRanks;
-    }
-    return false;
-  }
-
-  async setUserRelativeRanking(user: UserDto): Promise<Rank> {
-    const users = await this.userRepository.findAll({}, true, ['lowerUsername', 'tier', 'score']);
-    let tierRank = 0;
-    for (let rank = 0; rank < users.length; rank++) {
-      if (users[rank].lowerUsername === user.lowerUsername) {
-        const rankInfo = {
-          totalRank: rank + 1,
-          tierRank: tierRank + 1,
-        };
-        await this.userRepository.setCachedUserRank(user.id + '&', rankInfo);
-        return rankInfo;
-      }
-      if (users[rank].tier === user.tier) {
-        tierRank += 1;
-      }
-    }
-  }
 }


### PR DESCRIPTION
# :eyes: What is this PR?
- Nestjs App Load시, HTTP 요청 받기 전까지 block하면서 user score정보 redis에 dump하기
- 유저 프로필 페이지 들어가면, findCachedRank('all&',이름), findCachedRank('tier&',이름) 으로 순위 정보 추가하기
- 유저 업데이트 시, 일단 'all&'에는 무조건 upsert. 2가지 케이스 존재
    1. 업데이트로 인해 티어가 변경되지 않는 경우 : '티어&'에 유저 upsert
    2. 업데이트로 인해 티어가 변경되는 경우 : 이전 '이전티어&'에서 해당 유저 삭제 && '새티어&'에 유저 추가
- 랭킹페이지 페이지네이션에서 전체 유저 기준 등수 추가

# :pushpin: Related issue(s)

# :pencil: Changes

# :camera: Attachment
