### PR TITLE
Refactor: refresh button error handling

### DIFF
--- a/frontend/src/pages/profile/[username].tsx
+++ b/frontend/src/pages/profile/[username].tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
+import { AxiosError } from 'axios';
 import { useEffect } from 'react';
 import styled from 'styled-components';
 import { useQueryData } from '@hooks';
@@ -29,10 +30,20 @@ function Profile({ username }: ProfileProps) {
 
   const { mutate, isLoading } = useMutation<ProfileUserResponse>({
     mutationFn: () => requestUserInfoByUsername({ username, method: 'PATCH' }),
-    onError: () => alert('최근에 업데이트 했습니다.'),
+    onError: (err) => updateErrorHandler(err),
     onSettled: () => refetch(),
   });
+
   const { t } = useTranslation(['profile', 'meta']);
+  const updateErrorHandler = (err: unknown) => {
+    if (err instanceof AxiosError && err.response) {
+      if (err.response.status >= 500) {
+        alert('정보를 불러올 수 없는 유저입니다.');
+      } else if (err.response.status >= 400) {
+        alert('최근에 업데이트 했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
+  };
 
   useEffect(() => {
     requestTokenRefresh();

--- a/frontend/src/utils/axiosInstance.ts
+++ b/frontend/src/utils/axiosInstance.ts
@@ -34,6 +34,10 @@ instance.interceptors.response.use(
         }
       }
     }
+
+    if (originConfig.url.startsWith('/users/') && originConfig.method === 'patch') {
+      return Promise.reject(err);
+    }
   },
 );
 


### PR DESCRIPTION
# :eyes: What is this PR?
refresh button error handling

# :pushpin: Related issue(s)
- close #344 

# :pencil: Changes
- response status 400인 경우 "최근에 업데이트한 유저입니다." 알림
- response status 500인 경우 "정보를 업데이트 할 수 없는 유저입니다." 알림

# :camera: Attachment
![스크린샷 2022-12-16 오전 11 22 31](https://user-images.githubusercontent.com/79798443/208007293-f4ec33b3-3f2c-497e-a68b-241a29a3c0a5.png)
![스크린샷 2022-12-16 오전 11 23 04](https://user-images.githubusercontent.com/79798443/208007354-0c77ea43-02d3-4d43-942d-ce874fcd24b2.png)
